### PR TITLE
PR from my local branch to severalnines/s9s-ansible

### DIFF
--- a/inv/staging
+++ b/inv/staging
@@ -1,0 +1,5 @@
+[defaults]
+environ=staging
+
+[staging]
+127.0.0.1

--- a/inventory/group_vars/sample_prod/add_lb/mariadb_galera_haproxy_hg2
+++ b/inventory/group_vars/sample_prod/add_lb/mariadb_galera_haproxy_hg2
@@ -1,0 +1,64 @@
+## RPC V2 compatible
+use_rpcv2: true
+cluster_name: "mariadb-10.6-cluster"
+cluster_type: "galera"
+proxy_type: "haproxy"
+prefix: "haproxy://"
+proxy_hosts:
+    - host: 192.168.40.51
+      ha_port: 9600
+      rw_splitting: true
+      node_type: active
+      backend_name_ro: haproxy_2208_ro
+      backend_name_rw: haproxy_2207_rw
+      node_addresses: 192.168.40.50:3306:active,,192.168.40.51:3306:active,192.168.40.52:3306:active
+      lb_admin: myhaproxyAdmin
+      lb_password: myhaproxyPassword
+      disable_firewall: true
+      disable_selinux: true
+      overwrite_mysqlchk: true
+      lb_policy: leastconn
+      max_connection_be: 64
+      max_connection_fe: 8192
+      ro_port: 3308
+      rw_port: 3307
+      rw_splitting: true
+      stats_socket: /var/run/haproxy.socket
+      timeout_client: 10800
+      timeout_server: 10800
+      xinetd_allow_from: 0.0.0.0/0
+      build_from_source: false	  
+    - host: 192.168.40.52
+      ha_port: 9600
+      rw_splitting: true
+      node_type: active
+      backend_name_ro: haproxy_2208_ro
+      backend_name_rw: haproxy_2207_rw
+      node_addresses: 192.168.40.50:3306:active,,192.168.40.51:3306:backup,192.168.40.52:3306:active
+      lb_admin: myhaproxyAdmin
+      lb_password: myhaproxyPassword
+      disable_firewall: true
+      disable_selinux: true
+      overwrite_mysqlchk: true
+      lb_policy: leastconn
+      max_connection_be: 64
+      max_connection_fe: 8192
+      port: 9600
+      ro_port: 3308
+      rw_port: 3307
+      rw_splitting: true
+      stats_socket: /var/run/haproxy.socket
+      timeout_client: 10800
+      timeout_server: 10800
+      xinetd_allow_from: 0.0.0.0/0  
+      build_from_source: false
+
+# s9s cluster --cluster-id=32 --add-node --nodes="haproxy://192.168.40.22:8422?backend_name_ro=haproxy_2208_ro&backend_name_rw=haproxy_2207_rw&lb_user=myhaproxyAdmin&lb_password=myhaproxyPass&rw_splitting=true&node_addresses=192.168.40.20:3306?active,192.168.40.21:3306?backup,192.168.40.22:3306?backup" --wait --log --print-request
+
+
+rpc_user: myuser
+rpc_password: myuserpass
+# RPC V2 URL should have the v2/jobs as it's sub-directory in the URL. If you need to change the URL, likely you'll change only the IP address 
+## such as your hostname or any FQDN that points to the RPC V2 running in your CC Controller host. In this example, we're using localhost.
+rpc_v2_url: https://127.0.0.1:9501/v2/jobs
+#curl -k -XPOST "https://127.0.0.1:9501/v2/jobs" -d"{\"cluster_id\":87,\"operation\":\"createJobInstance\",\"job\":{\"class_name\":\"CmonJobInstance\",\"job_spec\":{\"command\":\"setup_audit_logging\",\"job_data\":{\"action\": \"enable\",\"clusterId\": \"87\"}},\"title\":\"Setup audit Logging\"},\"authenticate\":{\"username\":\"myuser\",\"password\":\"myuserpass\"}}"

--- a/inventory/group_vars/sample_prod/add_lb/mysql_repl_haproxy_c1
+++ b/inventory/group_vars/sample_prod/add_lb/mysql_repl_haproxy_c1
@@ -1,36 +1,38 @@
+## RPC V2 compatible
+use_rpcv2: true
 cluster_name: "mysql-replication-c1"
-cluster_type: "replication"
+cluster_type: replication
 proxy_type: "haproxy"
 prefix: "haproxy://"
 proxy_hosts:
-    # - host: 192.168.40.23
-    #   ha_port: 8422
-    #   rw_splitting: true
-      # node_type: active
-      # backend_name_ro: haproxy_2208_ro
-      # backend_name_rw: haproxy_2207_rw
-      # lb_user: myhaproxyAdmin
-      # lb_password: lb_password
-      # node_addresses: 192.168.40.20:3306?active,192.168.40.21:3306?backup,192.168.40.22:3306?backup
-    - host: 192.168.40.57
-      ha_port: 8422
+    - host: 192.168.40.62
+      ha_port: 9600
       rw_splitting: true
-      # node_type: backup
-      # backend_name_ro: haproxy_2208_ro
-      # backend_name_rw: haproxy_2207_rw
-      # lb_user: myhaproxyAdmin
-      # lb_password: lb_password
-      # node_addresses: 192.168.40.20:3306?active,192.168.40.21:3306?backup,192.168.40.22:3306?backup
-    # - host: 192.168.40.22
-    #   ha_port: 8422
-    #   node_type: active
-    #   rw_splitting: true
-    #   node_type: backup
-      # backend_name_ro: haproxy_2208_ro
-      # backend_name_rw: haproxy_2207_rw
-      # lb_user: myhaproxyAdmin
-      # lb_password: lb_password
-      # node_addresses: 192.168.40.20:3306?active,192.168.40.21:3306?backup,192.168.40.22:3306?backup
-wait_log: "--wait --log"
+      node_type: active
+      backend_name_ro: haproxy_2208_ro
+      backend_name_rw: haproxy_2207_rw
+      node_addresses: 192.168.40.60:3306:active,,192.168.40.61:3306:active
+      lb_admin: myhaproxyAdmin
+      lb_password: myhaproxyPassword
+      disable_firewall: true
+      disable_selinux: true
+      overwrite_mysqlchk: true
+      lb_policy: leastconn
+      max_connection_be: 64
+      max_connection_fe: 8192
+      ro_port: 3308
+      rw_port: 3307
+      rw_splitting: true
+      stats_socket: /var/run/haproxy.socket
+      timeout_client: 10800
+      timeout_server: 10800
+      xinetd_allow_from: 0.0.0.0/0
+      build_from_source: false	  
 
-# s9s cluster --cluster-id=32 --add-node --nodes="haproxy://192.168.40.22:8422?backend_name_ro=haproxy_2208_ro&backend_name_rw=haproxy_2207_rw&lb_user=myhaproxyAdmin&lb_password=myhaproxyPass&rw_splitting=true&node_addresses=192.168.40.20:3306?active,192.168.40.21:3306?backup,192.168.40.22:3306?backup" --wait --log --print-request
+
+
+rpc_user: myuser
+rpc_password: myuserpass
+# RPC V2 URL should have the v2/jobs as it's sub-directory in the URL. If you need to change the URL, likely you'll change only the IP address 
+## such as your hostname or any FQDN that points to the RPC V2 running in your CC Controller host. In this example, we're using localhost.
+rpc_v2_url: https://127.0.0.1:9501/v2/jobs

--- a/inventory/group_vars/sample_prod/add_lb/mysql_repl_proxysql_8.0_c1
+++ b/inventory/group_vars/sample_prod/add_lb/mysql_repl_proxysql_8.0_c1
@@ -1,0 +1,19 @@
+cluster_name: "mysql-8.3-latest-repl"
+cluster_type: "replication"
+proxy_admin_user: "proxysql-admin"
+proxy_admin_password: "admin"
+proxy_monitor_user: "proxysql-monitor"
+proxy_monitor_password: "monitor"
+prefix: "proxysql://"
+proxy_hosts:
+    - host: 192.168.40.52
+      port: 6032
+    - host: 192.168.40.53
+      port: 6032
+wait_log: "--wait --log"
+
+## optional db user to add
+db_username: "proxysql-paul"
+db_password: "admin"
+db_database: "*.*"
+db_privs: "ALL PRIVILEGES"

--- a/inventory/group_vars/sample_prod/add_lb/mysql_repl_proxysql_8.0_c1_rpcv2
+++ b/inventory/group_vars/sample_prod/add_lb/mysql_repl_proxysql_8.0_c1_rpcv2
@@ -1,0 +1,64 @@
+## RPC V2 compatible
+use_rpcv2: true
+prefix: "proxysql://"
+cluster_name: "mysql-8.3-latest-repl"
+cluster_type: "replication"
+proxy_hosts:
+    - proxyhostname: 192.168.40.52
+      proxyhostport: 6032
+      db_username: proxysql-paul
+      db_password: admin
+      db_database: "*.*"
+      db_privs: ALL PRIVILEGES
+      disable_firewall: true
+      disable_selinux: true
+      listening_port: 6033
+      admin_user: "proxysql-admin"
+      admin_password: admin
+      monitor_user: proxysql-monitor
+      monitor_password: "monitor"
+      use_clustering: false
+      use_rw_split: true
+      version: 2
+      database_nodes:
+        - node_hostname: 192.168.40.52
+          max_connection: 100
+          max_replication_lag: 10
+          port: 3306
+          weight: 1
+        - node_hostname: 192.168.40.53
+          max_connection: 100
+          max_replication_lag: 10
+          port: 3306
+          weight: 1
+    - proxyhostname: 192.168.40.53
+      proxyhostport: 6032
+      db_username: proxysql-paul
+      db_password: admin
+      db_database: "*.*"
+      db_privs: ALL PRIVILEGES
+      disable_firewall: true
+      disable_selinux: true
+      listening_port: 6033
+      admin_user: "proxysql-admin"
+      admin_password: admin
+      monitor_user: proxysql-monitor
+      monitor_password: "monitor"
+      use_clustering: false
+      use_rw_split: true
+      version: 2
+      database_nodes:
+        - node_hostname: 192.168.40.52
+          max_connection: 100
+          max_replication_lag: 10
+          port: 3306
+          weight: 1
+        - node_hostname: 192.168.40.53
+          max_connection: 100
+          max_replication_lag: 10
+          port: 3306
+          weight: 1
+
+rpc_user: myrpcuser
+rpc_password: myrpcpword
+rpc_v2_url: https://127.0.0.1:9501/v2/jobs

--- a/inventory/group_vars/sample_prod/deploy/elasticsearch_eprod1
+++ b/inventory/group_vars/sample_prod/deploy/elasticsearch_eprod1
@@ -6,12 +6,16 @@ db_admin_user: elasticsearch
 db_admin_password: mydbP@55w0rd
 ## port cannot be customized as of this time so it's not required.
 db_nodes:
-    - host: 192.168.40.136
+    - host: 192.168.40.45
       roles: master-data
-    - host: 192.168.40.137
+    - host: 192.168.40.41
       roles: master-data
-    - host: 192.168.40.138
+    - host: 192.168.40.42
       roles: master-data
+    - host: 192.168.40.43
+      roles: data
+    - host: 192.168.40.44
+      roles: data
 # cluster_tags should be comma delimited without any space in between
 cluster_tags: "prod,es-eprod1"
 wait_log: "--wait --log"
@@ -19,4 +23,4 @@ prefix: "elastic://"
 snapshot_location: /mnt/data/backups/es-snapshot-repositories
 snapshot_repository_name: elasticsearch_snapshots
 snapshot_repo_type: fs
-snapshot_storage_host: 192.168.40.135
+snapshot_storage_host: 192.168.40.43

--- a/inventory/group_vars/sample_prod/deploy/mariadb_galera_iceland
+++ b/inventory/group_vars/sample_prod/deploy/mariadb_galera_iceland
@@ -1,0 +1,20 @@
+cluster_name: "mariadb-10.5-iceland"
+cluster_type: "galera"
+vendor: "mariadb"
+db_admin_user: root
+db_admin_password: mydbP@55w0rd
+version: "10.5"
+db_nodes:
+    - host: 192.168.40.55
+      port: 3306
+      node_type: master
+    - host: 192.168.40.56
+      port: 3306
+      node_type: master
+    - host: 192.168.40.57
+      port: 3306
+      node_type: master
+# cluster_tags should be comma delimited without any space in between
+cluster_tags: "prod,iceland"
+wait_log: "--wait --log"
+prefix: "mysql://"

--- a/inventory/group_vars/sample_prod/deploy/mariadb_repl_c2
+++ b/inventory/group_vars/sample_prod/deploy/mariadb_repl_c2
@@ -1,18 +1,20 @@
-cluster_name: "mariadb-10.6_c1"
+cluster_name: "mariadb-10.6_c2"
 cluster_type: replication
 vendor: "mariadb"
 version: "10.6"
 db_admin_user: mydbadmin
 db_admin_password: mydbP@55w0rd
 db_nodes:
-    - host: 192.168.40.50
+    - host: 192.168.40.52
       port: 3306
       node_type: master
-    - host: 192.168.40.51
+    - host: 192.168.40.53
       port: 3306
       node_type: slave
+    - host: 192.168.40.54
+      port: 3306
       node_type: slave
 # cluster_tags should be comma delimited without any space in between
-cluster_tags: "c1"
+cluster_tags: "c2,manifone,emmanuel,ticket_8980"
 wait_log: "--wait --log"
 prefix: "mysql://"

--- a/inventory/group_vars/sample_prod/deploy/mysql_oracle_repl_c1
+++ b/inventory/group_vars/sample_prod/deploy/mysql_oracle_repl_c1
@@ -1,17 +1,17 @@
-cluster_name: "mysql-replication-c1"
-cluster_type: msqlreplication
+cluster_name: "mysql-8.3-latest-repl"
+cluster_type: replication
 vendor: "oracle"
 version: "8.0"
-db_admin_user: root
+db_admin_user: mydbadmin
 db_admin_password: mydbP@55w0rd
 db_nodes:
-    - host: 192.168.40.53
+    - host: 192.168.40.52
       port: 3306
       node_type: master
-    - host: 192.168.40.57
+    - host: 192.168.40.53
       port: 3306
       node_type: slave
 # cluster_tags should be comma delimited without any space in between
-cluster_tags: "prod,c1-group"
-wait_log: "--wait --log"
+cluster_tags: "kimoby"
 prefix: "mysql://"
+wait_log: "--wait --log"

--- a/inventory/group_vars/sample_prod/drop_cluster/mariadb_10.6_cluster
+++ b/inventory/group_vars/sample_prod/drop_cluster/mariadb_10.6_cluster
@@ -1,0 +1,3 @@
+cluster_name: "mariadb-10.6-cluster"
+cluster_type: galera
+wait_log: "--wait --log"

--- a/inventory/group_vars/sample_prod/unregister/mariadb_galera_haproxy_hg2
+++ b/inventory/group_vars/sample_prod/unregister/mariadb_galera_haproxy_hg2
@@ -1,0 +1,7 @@
+cluster_name: "mariadb-10.6-cluster"
+cluster_type: "galera"
+nodes:
+    - host: 192.168.40.50
+      port: 9600
+wait_log: "--wait --log"
+uninstall: true

--- a/inventory/group_vars/sample_prod/unregister/mysql_repl_proxysql_8.0_c1_rpcv2
+++ b/inventory/group_vars/sample_prod/unregister/mysql_repl_proxysql_8.0_c1_rpcv2
@@ -1,0 +1,8 @@
+cluster_name: "mysql-8.3-latest-repl"
+cluster_type: "replication"
+nodes:
+    - host: 192.168.40.52
+      port: 6032
+    - host: 192.168.40.53
+      port: 6032
+wait_log: "--wait --log"

--- a/inventory/group_vars/staging/add_lb/mariadb_repl_haproxy_c1
+++ b/inventory/group_vars/staging/add_lb/mariadb_repl_haproxy_c1
@@ -1,0 +1,64 @@
+## RPC V2 compatible
+use_rpcv2: true
+cluster_name: "mariadb-replication-c1"
+cluster_type: "replication"
+proxy_type: "haproxy"
+prefix: "haproxy://"
+proxy_hosts:
+    - host: 192.168.40.58
+      ha_port: 9600
+      rw_splitting: true
+      node_type: active
+      backend_name_ro: haproxy_2208_ro
+      backend_name_rw: haproxy_2207_rw
+      node_addresses: 192.168.40.58:3306:active,192.168.40.59:3306:backup
+      lb_admin: myhaproxyAdmin
+      lb_password: myhaproxyPassword
+      disable_firewall: true
+      disable_selinux: true
+      overwrite_mysqlchk: true
+      lb_policy: leastconn
+      max_connection_be: 64
+      max_connection_fe: 8192
+      ro_port: 3308
+      rw_port: 3307
+      rw_splitting: true
+      stats_socket: /var/run/haproxy.socket
+      timeout_client: 10800
+      timeout_server: 10800
+      xinetd_allow_from: 0.0.0.0/0
+      build_from_source: false	  
+    - host: 192.168.40.59
+      ha_port: 9600
+      rw_splitting: true
+      node_type: active
+      backend_name_ro: haproxy_2208_ro
+      backend_name_rw: haproxy_2207_rw
+      node_addresses: 192.168.40.58:3306:active,192.168.40.59:3306:backup
+      lb_admin: myhaproxyAdmin
+      lb_password: myhaproxyPassword
+      disable_firewall: true
+      disable_selinux: true
+      overwrite_mysqlchk: true
+      lb_policy: leastconn
+      max_connection_be: 64
+      max_connection_fe: 8192
+      port: 9600
+      ro_port: 3308
+      rw_port: 3307
+      rw_splitting: true
+      stats_socket: /var/run/haproxy.socket
+      timeout_client: 10800
+      timeout_server: 10800
+      xinetd_allow_from: 0.0.0.0/0
+      build_from_source: false
+
+# s9s cluster --cluster-id=32 --add-node --nodes="haproxy://192.168.40.22:8422?backend_name_ro=haproxy_2208_ro&backend_name_rw=haproxy_2207_rw&lb_user=myhaproxyAdmin&lb_password=myhaproxyPass&rw_splitting=true&node_addresses=192.168.40.20:3306?active,192.168.40.21:3306?backup,192.168.40.22:3306?backup" --wait --log --print-request
+
+
+rpc_user: myuser
+rpc_password: myuserpass
+# RPC V2 URL should have the v2/jobs as it's sub-directory in the URL. If you need to change the URL, likely you'll change only the IP address 
+## such as your hostname or any FQDN that points to the RPC V2 running in your CC Controller host. In this example, we're using localhost.
+rpc_v2_url: https://127.0.0.1:9501/v2/jobs
+#curl -k -XPOST "https://127.0.0.1:9501/v2/jobs" -d"{\"cluster_id\":87,\"operation\":\"createJobInstance\",\"job\":{\"class_name\":\"CmonJobInstance\",\"job_spec\":{\"command\":\"setup_audit_logging\",\"job_data\":{\"action\": \"enable\",\"clusterId\": \"87\"}},\"title\":\"Setup audit Logging\"},\"authenticate\":{\"username\":\"myuser\",\"password\":\"myuserpass\"}}"

--- a/inventory/group_vars/staging/add_lb/mariadb_repl_proxysql_c1
+++ b/inventory/group_vars/staging/add_lb/mariadb_repl_proxysql_c1
@@ -1,14 +1,14 @@
-cluster_name: "mariadb-cluster-hg2"
-cluster_type: "galera"
+cluster_name: "mariadb-replication-c1"
+cluster_type: replication
 proxy_admin_user: "proxysql-admin"
 proxy_admin_password: "admin"
 proxy_monitor_user: "proxysql-monitor"
 proxy_monitor_password: "monitor"
 prefix: "proxysql://"
 proxy_hosts:
-    - host: 192.168.40.51
+    - host: 192.168.40.58
       port: 6032
-    - host: 192.168.40.52
+    - host: 192.168.40.59
       port: 6032
 wait_log: "--wait --log"
 

--- a/inventory/group_vars/staging/add_node/mariadb_repl_c1_replica59
+++ b/inventory/group_vars/staging/add_node/mariadb_repl_c1_replica59
@@ -1,0 +1,10 @@
+cluster_name: "mariadb-replication-c1"
+cluster_type: replication
+vendor: "mariadb"
+version: "10.5"
+db_nodes:
+    - host: 192.168.40.59
+      port: 3306
+      node_type: slave
+wait_log: "--wait --log"
+prefix: "mysql://"

--- a/inventory/group_vars/staging/backup/mariadb_repl_c1_mysqldump
+++ b/inventory/group_vars/staging/backup/mariadb_repl_c1_mysqldump
@@ -1,0 +1,10 @@
+cluster_name: "mariadb-replication-c1"
+cluster_type: replication
+backup_method: "mysqldump"
+backup_directory: /home/vagrant/backups
+store_on_controller: false
+backup_retention: 2
+node:
+    - host: 192.168.40.59
+      port: 3306
+wait_log: --log --wait

--- a/inventory/group_vars/staging/backup/mariadb_repl_c1_restore
+++ b/inventory/group_vars/staging/backup/mariadb_repl_c1_restore
@@ -1,0 +1,7 @@
+cluster_name: "mariadb-replication-c1"
+cluster_type: replication
+backup_title: BACKUP-146
+node:
+    - host: 192.168.40.58
+      port: 3306
+wait_log: '--wait --log'

--- a/inventory/group_vars/staging/backup/mariadb_repl_c1_xtrabackupfull
+++ b/inventory/group_vars/staging/backup/mariadb_repl_c1_xtrabackupfull
@@ -1,0 +1,11 @@
+cluster_name: "mariadb-replication-c1"
+cluster_type: replication
+backup_method: "mariabackupfull"
+backup_directory: /home/vagrant/backups
+store_on_controller: true
+backup_schedule: 10 22 * * *
+backup_retention: 2
+node:
+    - host: 192.168.40.59
+      port: 3306
+wait_log: '--wait --log'

--- a/inventory/group_vars/staging/deploy/mariadb_repl_c1
+++ b/inventory/group_vars/staging/deploy/mariadb_repl_c1
@@ -1,18 +1,17 @@
-cluster_name: "mariadb-10.6_c1"
+cluster_name: "mariadb-replication-c1"
 cluster_type: replication
 vendor: "mariadb"
-version: "10.6"
-db_admin_user: mydbadmin
+version: "10.5"
+db_admin_user: root
 db_admin_password: mydbP@55w0rd
 db_nodes:
-    - host: 192.168.40.50
+    - host: 192.168.40.58
       port: 3306
       node_type: master
-    - host: 192.168.40.51
+    - host: 192.168.40.59
       port: 3306
       node_type: slave
-      node_type: slave
 # cluster_tags should be comma delimited without any space in between
-cluster_tags: "c1"
+cluster_tags: "prod,c1-group"
 wait_log: "--wait --log"
 prefix: "mysql://"

--- a/inventory/group_vars/staging/drop_cluster/mysql_repl_c1
+++ b/inventory/group_vars/staging/drop_cluster/mysql_repl_c1
@@ -1,0 +1,4 @@
+cluster_name: "mariadb-replication-c1"
+cluster_type: replication
+wait_log: "--wait --log"
+remove_backups: true

--- a/inventory/group_vars/staging/manage/dashboard_mariadb_repl_c1
+++ b/inventory/group_vars/staging/manage/dashboard_mariadb_repl_c1
@@ -1,0 +1,26 @@
+cluster_name: "mariadb-replication-c1"
+cluster_type: replication
+enable_dash: "{{ enable |d(true) }}"
+let_it_run_and_no_uninstall: false
+data_retention: 15d
+data_retention_size: 0
+datadir:
+prometheus_host: 192.168.40.63
+scrape_interval: 10s
+# make sure when adding values to the parameters make sure you have escaped the quotes and the values are inside
+## the quotes as well.
+configuration: '[
+{
+  \"arguments\": \"\",
+  \"job\": \"node\",
+  \"scrape_interval\":\"\"
+},
+{
+  \"arguments\": \"--collect.perf_schema.eventswaits --collect.perf_schema.file_events --collect.perf_schema.file_instances --collect.perf_schema.indexiowaits --collect.perf_schema.tableiowaits --collect.perf_schema.tablelocks --collect.info_schema.tablestats --collect.info_schema.processlist --collect.binlog_size --collect.global_status --collect.global_variables --collect.info_schema.innodb_metrics --collect.slave_status --collect.info_schema.userstats\",
+  \"job\": \"mariadbd\",
+  \"scrape_interval\":\"\"
+}
+]'
+rpc_user: myuser
+rpc_password: myuserpass
+rpc_v2_url: https://127.0.0.1:9501/v2/jobs

--- a/inventory/group_vars/staging/manage/querymonitor_mariadb_repl_c1
+++ b/inventory/group_vars/staging/manage/querymonitor_mariadb_repl_c1
@@ -1,0 +1,8 @@
+cluster_name: "mariadb-replication-c1"
+cluster_type: replication
+enable_qm: "{{ enable |d(true) }}"
+rpc_user: myuser
+rpc_password: myuserpass
+# RPC V2 URL should have the v2/jobs as it's sub-directory in the URL. If you need to change the URL, likely you'll change only the IP address 
+## such as your hostname or any FQDN that points to the RPC V2 running in your CC Controller host. In this example, we're using localhost.
+rpc_v2_url: https://127.0.0.1:9501/v2/jobs

--- a/inventory/group_vars/staging/staging_common
+++ b/inventory/group_vars/staging/staging_common
@@ -1,0 +1,2 @@
+os_user: "vagrant"
+os_key_file: "/home/vagrant/.ssh/id_rsa"

--- a/inventory/group_vars/staging/unregister/mariadb_repl_c1_ha_proxy_db
+++ b/inventory/group_vars/staging/unregister/mariadb_repl_c1_ha_proxy_db
@@ -1,0 +1,15 @@
+cluster_name: "mariadb-replication-c1"
+cluster_type: "replication"
+nodes:
+    - host: 192.168.40.58
+      port: 9600
+    - host: 192.168.40.59
+      port: 9600
+    - host: 192.168.40.58
+      port: 6032
+    - host: 192.168.40.59
+      port: 6032
+    - host: 192.168.40.59
+      port: 3306
+wait_log: "--wait --log"
+uninstall: true

--- a/playbooks/add-loadbalancer-proxysql.yml
+++ b/playbooks/add-loadbalancer-proxysql.yml
@@ -35,8 +35,8 @@
         set_fact:
             loadbalancer: 1
         when: >
-             item[1].split()[4] is defined and item[1].split()[4]|trim == item[0].host|trim and
-             item[1].split()[5] is defined and item[1].split()[5]|trim == item[0].port|trim
+             item[1].split()[4] is defined and item[1].split()[4]|trim == item[0].proxyhostname|trim and
+             item[1].split()[5] is defined and item[1].split()[5]|trim == item[0].proxyhostport|trim
         with_nested:
         - "{{ proxy_hosts }}"
         - "{{ node_list.stdout_lines }}"
@@ -49,10 +49,15 @@
     -   name: Set the retry count
         set_fact:
              retry_count: 0
+             retry_count_dbs: 0
+             node_addresses: ""
 
-    -   include_tasks: helpers/multi-node-deploy-proxysql.yml
+    # -   include_tasks: helpers/multi-node-deploy-proxysql.yml
+    #     when: retry_count | int < proxy_hosts|length
+
+    -   name: Including tasks helpers/multi-node-deploy-proxysql_rpcv2.yml
+        include_tasks: helpers/multi-node-deploy-proxysql_rpcv2.yml
         when: retry_count | int < proxy_hosts|length
-
 
     # -   name: Separate the hosts via comma delimiter to allow multiple host deployments
     #     set_fact:

--- a/playbooks/helpers/multi-node-deploy-proxysql_rpcv2.yml
+++ b/playbooks/helpers/multi-node-deploy-proxysql_rpcv2.yml
@@ -1,0 +1,108 @@
+-   name: Including tasks helpers/multi-node-deploy-proxysql_rpcv2_dbnodes.yml
+    include_tasks: helpers/multi-node-deploy-proxysql_rpcv2_dbnodes.yml
+    when: use_rpcv2|d(false)|bool == true and valid_play|d(true)|bool == true and retry_count_dbs | int < proxy_hosts[retry_count|int].database_nodes|length
+
+#   when: use_rpcv2|d(false)|bool == true and valid_play|d(true)|bool == true and retry_count | int < proxy_hosts|length
+
+-   name: Clean up node_addresses variable (remove trailing comma) and reset dependent variables
+    set_fact:
+       node_addresses_mapjson: "{{node_addresses[:-1] }}"
+       node_addresses: ""
+       retry_count_dbs: 0
+    when: use_rpcv2|d(false)|bool == true and valid_play|d(true)|bool == true and node_addresses|length > 0
+
+-   name: Showing debug command using RPC V2 to deploy and install ProxySQL load balancer
+    debug:
+         msg: >-
+            curl -k -v -XPOST "{{ rpc_v2_url }}" -d"
+            {
+               \"cluster_id\":{{ cluster_id }},
+               \"operation\":\"createJobInstance\",
+               \"job\":{
+                   \"class_name\":\"CmonJobInstance\",
+                   \"job_spec\":{
+                      \"command\":\"proxysql\",
+                       \"job_data\":{
+                          \"action\":\"setupProxySql\",
+                          \"admin_password\":\"{{ proxy_hosts[retry_count|int].admin_password }}\",
+                          \"admin_user\":\"{{ proxy_hosts[retry_count|int].admin_user }}\",
+                          \"db_database\":\"{{ proxy_hosts[retry_count|int].db_database }}\",
+                          \"db_password\":\"{{ proxy_hosts[retry_count|int].db_password }}\",
+                          \"db_privs\":\"{{ proxy_hosts[retry_count|int].db_privs }}\",
+                          \"disable_firewall\":{% if proxy_hosts[retry_count|int].disable_firewall|bool == true %}true{%else%}false{% endif %},
+                          \"disable_selinux\":{% if proxy_hosts[retry_count|int].disable_selinux|bool == true %}true{%else%}false{% endif %},
+                          \"listening_port\":\"{{ proxy_hosts[retry_count|int].listening_port }}\",
+                          \"monitor_password\":\"{{ proxy_hosts[retry_count|int].monitor_password }}\",
+                          \"monitor_user\":\"{{ proxy_hosts[retry_count|int].monitor_user }}\",
+                          \"use_clustering\":{% if proxy_hosts[retry_count|int].use_clustering|bool == true %}true{%else%}false{% endif %},
+                          \"use_rw_split\":{% if proxy_hosts[retry_count|int].use_rw_split|bool == true %}true{%else%}false{% endif %},
+                          \"version\":\"{{ proxy_hosts[retry_count|int].version }}\",
+                          \"node\":{
+                                \"hostname\":\"{{ proxy_hosts[retry_count|int].proxyhostname }}\",
+                                \"port\": {{ proxy_hosts[retry_count|int].proxyhostport }}
+                         },
+                          \"node_addresses\": [{{ node_addresses_mapjson }}    ]
+                      }
+                  },
+                  \"title\":\"Adding ProxySQL Load Balancer To Cluster ID: {{ cluster_id }}\"
+              },
+              \"authenticate\":{
+                  \"username\":\"{{ rpc_user }}\",
+                  \"password\":\"{{ rpc_password }}\"
+              }
+            }"
+    when: use_rpcv2|d(false)|bool == true and valid_play|d(true)|bool == true and retry_count | int < proxy_hosts|length
+
+
+-   name: Execute cURL using RPC V2 to deploy and install ProxySQL load balancer
+    command: >-
+        curl -k -v -XPOST "{{ rpc_v2_url }}" -d"
+        {
+           \"cluster_id\":{{ cluster_id }},
+           \"operation\":\"createJobInstance\",
+           \"job\":{
+               \"class_name\":\"CmonJobInstance\",
+               \"job_spec\":{
+                  \"command\":\"proxysql\",
+                   \"job_data\":{
+                      \"action\":\"setupProxySql\",
+                      \"admin_password\":\"{{ proxy_hosts[retry_count|int].admin_password }}\",
+                      \"admin_user\":\"{{ proxy_hosts[retry_count|int].admin_user }}\",
+                      \"db_username\":\"{{ proxy_hosts[retry_count|int].db_username }}\",
+                      \"db_password\":\"{{ proxy_hosts[retry_count|int].db_password }}\",
+                      \"db_privs\":\"{{ proxy_hosts[retry_count|int].db_privs }}\",
+                      \"db_database\":\"{{ proxy_hosts[retry_count|int].db_database }}\",
+                      \"disable_firewall\":{% if proxy_hosts[retry_count|int].disable_firewall|bool == true %}true{%else%}false{% endif %},
+                      \"disable_selinux\":{% if proxy_hosts[retry_count|int].disable_selinux|bool == true %}true{%else%}false{% endif %},
+                      \"listening_port\":\"{{ proxy_hosts[retry_count|int].listening_port }}\",
+                      \"monitor_password\":\"{{ proxy_hosts[retry_count|int].monitor_password }}\",
+                      \"monitor_user\":\"{{ proxy_hosts[retry_count|int].monitor_user }}\",
+                      \"use_clustering\":{% if proxy_hosts[retry_count|int].use_clustering|bool == true %}true{%else%}false{% endif %},
+                      \"use_rw_split\":{% if proxy_hosts[retry_count|int].use_rw_split|bool == true %}true{%else%}false{% endif %},
+                      \"version\":{{ proxy_hosts[retry_count|int].version|int }},
+                      \"node\":{
+                            \"hostname\":\"{{ proxy_hosts[retry_count|int].proxyhostname }}\",
+                            \"port\": {{ proxy_hosts[retry_count|int].proxyhostport }}
+                     },
+                      \"node_addresses\": [{{ node_addresses_mapjson }}    ]
+                  }
+              },
+              \"title\":\"Adding ProxySQL Load Balancer To Cluster ID: {{ cluster_id }}\"
+          },
+          \"authenticate\":{
+              \"username\":\"{{ rpc_user }}\",
+              \"password\":\"{{ rpc_password }}\"
+          }
+        }"
+    args:
+        warn: false
+    when: use_rpcv2|d(false)|bool == true and valid_play|d(true)|bool == true and retry_count | int < proxy_hosts|length
+
+-   name: Set increments based on the number of proxy host assigned
+    set_fact:
+        retry_count: "{{ retry_count | int + 1 }}"
+    when: use_rpcv2|d(false)|bool == true and valid_play|d(true)|bool == true and retry_count | int < proxy_hosts|length
+
+-   name: Including tasks helpers/multi-node-deploy-proxysql_rpcv2.yml (re-invocation)
+    include_tasks: helpers/multi-node-deploy-proxysql_rpcv2.yml
+    when: use_rpcv2|d(false)|bool == true and valid_play|d(true)|bool == true and retry_count | int < proxy_hosts|length

--- a/playbooks/helpers/multi-node-deploy-proxysql_rpcv2_dbnodes.yml
+++ b/playbooks/helpers/multi-node-deploy-proxysql_rpcv2_dbnodes.yml
@@ -1,0 +1,27 @@
+-   name: Set variable for node_addresses
+    set_fact:
+        node_addresses: >-
+               {{ node_addresses }}
+               {
+                   \"hostname\":\"{{ proxy_hosts[retry_count|int].database_nodes[retry_count_dbs|int].node_hostname }}\", 
+                   \"max_connection\":\"{{ proxy_hosts[retry_count|int].database_nodes[retry_count_dbs|int].max_connection }}\", 
+                   \"max_replication_lag\":\"{{ proxy_hosts[retry_count|int].database_nodes[retry_count_dbs|int].max_replication_lag }}\", 
+                   \"port\":\"{{  proxy_hosts[retry_count|int].database_nodes[retry_count_dbs|int].port }}\",
+                   \"weight\":{{ proxy_hosts[retry_count|int].database_nodes[retry_count_dbs|int].weight }}
+               },
+
+-   name: Set variable for node_addresses | debugging message only
+    debug:
+         msg: "Nothing but just printing debug message"
+
+
+    
+-   name: Set increments based on the number of proxy host database nodes assigned
+    set_fact:
+        retry_count_dbs: "{{ retry_count_dbs | int + 1 }}"
+    when: use_rpcv2|d(false)|bool == true and valid_play|d(true)|bool == true and retry_count_dbs | int < proxy_hosts[retry_count|int].database_nodes|length
+
+
+-   name: Including tasks helpers/multi-node-deploy-proxysql_rpcv2_dbnodes.yml (re-invocation)
+    include_tasks: helpers/multi-node-deploy-proxysql_rpcv2_dbnodes.yml
+    when: use_rpcv2|d(false)|bool == true and valid_play|d(true)|bool == true and retry_count_dbs | int < proxy_hosts[retry_count|int].database_nodes|length


### PR DESCRIPTION
   - resolve issues with ProxySQL where there's no way to add a ProxySQL
    node properly with s9s command (s9s command limitation)
    - use rpcv2 to resolve it and allow multiple deployments of ProxySQL
    depending on the node you desire to add. Take note, using RPC v2 uses
    cURL to request to cmon so there's no way to wait and collect logs but
    instead check on the CC UI or through s9s job command